### PR TITLE
Updated Auth and Profile logic, UI improvements, and nav graph updates

### DIFF
--- a/app/src/main/java/com/example/hoophubskeleton/ViewModel/AuthViewModel.kt
+++ b/app/src/main/java/com/example/hoophubskeleton/ViewModel/AuthViewModel.kt
@@ -54,4 +54,13 @@ class AuthViewModel(private val authRepository: AuthRepository) : ViewModel() {
             }
         }
     }
+
+    private val _deleteStatus = MutableLiveData<Pair<Boolean, String?>>()
+    val deleteStatus: LiveData<Pair<Boolean, String?>> get() = _deleteStatus
+
+    fun deleteUserCredentials() {
+        authRepository.deleteUserCredentials { success, message ->
+            _deleteStatus.value = Pair(success, message) // Update LiveData with the result
+        }
+    }
 }

--- a/app/src/main/java/com/example/hoophubskeleton/ViewModel/ProfileViewModel.kt
+++ b/app/src/main/java/com/example/hoophubskeleton/ViewModel/ProfileViewModel.kt
@@ -37,4 +37,18 @@ class ProfileViewModel(private val profileRepository: ProfileRepository) : ViewM
         }
     }
 
+    private val _deleteStatus = MutableLiveData<Pair<Boolean, String?>>()
+    val deleteStatus: LiveData<Pair<Boolean, String?>> get() = _deleteStatus
+
+    fun deleteUserProfile() {
+        profileRepository.deleteUserProfile { success, error ->
+            if (success) {
+                _userProfile.value = null // Clear the profile data from LiveData
+                _deleteStatus.value = Pair(true, null) // Notify success to the UI
+            } else {
+                _deleteStatus.value = Pair(false, error) // Notify failure to the UI
+            }
+        }
+    }
+
 }

--- a/app/src/main/java/com/example/hoophubskeleton/fragment/Auth/LoginFragment.kt
+++ b/app/src/main/java/com/example/hoophubskeleton/fragment/Auth/LoginFragment.kt
@@ -2,6 +2,7 @@ package com.example.hoophubskeleton.fragment.Auth
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -34,8 +35,10 @@ class LoginFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         // Initialize ViewModel
-        val authRepository = AuthRepository(FirebaseAuth.getInstance(), FirebaseFirestore.getInstance())
-        authViewModel = ViewModelProvider(this, AuthViewModelFactory(authRepository))[AuthViewModel::class.java]
+        val authRepository =
+            AuthRepository(FirebaseAuth.getInstance(), FirebaseFirestore.getInstance())
+        authViewModel =
+            ViewModelProvider(this, AuthViewModelFactory(authRepository))[AuthViewModel::class.java]
 
         val emailEditText: EditText = view.findViewById(R.id.emailEditText)
         val passwordEditText: EditText = view.findViewById(R.id.passwordEditText)
@@ -53,7 +56,8 @@ class LoginFragment : Fragment() {
                 // Navigate to MainFragment (hosting Players and Games tabs)
                 findNavController().navigate(R.id.action_loginFragment_to_mainFragment)
             } else {
-                Toast.makeText(requireContext(), "Login Failed: $message", Toast.LENGTH_SHORT).show()
+                Toast.makeText(requireContext(), "Login Failed: $message", Toast.LENGTH_SHORT)
+                    .show()
             }
         }
 
@@ -62,8 +66,18 @@ class LoginFragment : Fragment() {
             val email = emailEditText.text.toString()
             val password = passwordEditText.text.toString()
 
-            // Call the ViewModel to log in
-            authViewModel.logIn(email, password)
+            if (email.isNullOrBlank() || password.isNullOrBlank()) {
+                Toast.makeText(
+                    requireContext(),
+                    "Login Failed. Please fill out both fields.",
+                    Toast.LENGTH_SHORT
+                ).show()
+
+                Log.d("LoginFragment", "Login failure: User email or password blank")
+            } else {
+                // Call the ViewModel to log in
+                authViewModel.logIn(email, password)
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/hoophubskeleton/fragment/Auth/SignUpFragment.kt
+++ b/app/src/main/java/com/example/hoophubskeleton/fragment/Auth/SignUpFragment.kt
@@ -13,6 +13,7 @@ import android.widget.Button
 import android.widget.EditText
 import android.widget.ImageView
 import android.widget.RadioGroup
+import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
@@ -97,6 +98,20 @@ class SignUpFragment : Fragment() {
                 else -> ""
             }
 
+            // Validate inputs
+            if (email.isEmpty()) {
+                Toast.makeText(requireContext(), "Email cannot be empty.", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+            if (password.isEmpty()) {
+                Toast.makeText(requireContext(), "Password cannot be empty.", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+            if (name.isEmpty()) {
+                Toast.makeText(requireContext(), "Name cannot be empty.", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+
             uploadImageToFirebaseStorage { profilePicUrl ->
                 val user = User(
                     uid = "",
@@ -111,6 +126,22 @@ class SignUpFragment : Fragment() {
                 authViewModel.signUp(email, password, user)
             }
         }
+
+        // Observe the sign-up status
+        authViewModel.authStatus.observe(viewLifecycleOwner) { (success, message) ->
+            if (success) {
+                // Navigate to MainFragment upon successful sign-up
+                Toast.makeText(requireContext(), "Sign-up successful!: $message", Toast.LENGTH_SHORT).show()
+                findNavController().navigate(R.id.action_signUpFragment_to_mainFragment)
+            } else {
+                // Show error message if sign-up fails
+                Toast.makeText(requireContext(), "Sign-up failed: $message", Toast.LENGTH_SHORT)
+                    .show()
+            }
+        }
+
+
+
     }
 
     private fun openGallery() {

--- a/app/src/main/java/com/example/hoophubskeleton/repository/AuthRepository.kt
+++ b/app/src/main/java/com/example/hoophubskeleton/repository/AuthRepository.kt
@@ -74,4 +74,31 @@ class AuthRepository(
         }
     }
 
+    fun deleteUserCredentials(callback: (Boolean, String?) -> Unit) {
+        val uid = firebaseAuth.currentUser?.uid
+        val user = firebaseAuth.currentUser
+        if (uid != null && user != null) {
+            // delete user document in FirebaseAuth
+            firestore.collection("users").document(uid)
+                .delete()
+                .addOnSuccessListener {
+                    // delete user authentication account
+                    user.delete()
+                        .addOnSuccessListener {
+                            callback(true, null) // Success
+                        }
+                        .addOnFailureListener { exception ->
+                            callback(false, exception.message) // Failure
+                        }
+                }
+                .addOnFailureListener { exception ->
+                    callback(false, exception.message) // Failure with error message
+                }
+        } else {
+            callback(false, "User not logged in")
+        }
+    }
+
+
+
 }

--- a/app/src/main/java/com/example/hoophubskeleton/repository/ProfileRepository.kt
+++ b/app/src/main/java/com/example/hoophubskeleton/repository/ProfileRepository.kt
@@ -44,4 +44,20 @@ class ProfileRepository(
         }
     }
 
+    fun deleteUserProfile(callback: (Boolean, String?) -> Unit) {
+        val uid = firebaseAuth.currentUser?.uid
+        if (uid != null) {
+            firestore.collection("users").document(uid).delete()
+                .addOnSuccessListener {
+                    callback(true, null) // Success
+                }
+                .addOnFailureListener { e ->
+                    callback(false, e.message) // Failure
+                }
+        } else {
+            callback(false, "User not logged in")
+        }
+    }
+
+
 }

--- a/app/src/main/res/drawable/rounded_dialog_background.xml
+++ b/app/src/main/res/drawable/rounded_dialog_background.xml
@@ -1,0 +1,7 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="?attr/colorPrimary" /> <!-- Background color -->
+    <corners android:radius="16dp" /> <!-- Corner radius for rounded edges -->
+    <stroke
+        android:width="2dp"
+        android:color="?attr/colorAccent" /> <!-- Border color and width -->
+</shape>

--- a/app/src/main/res/layout/custom_alert_dialog.xml
+++ b/app/src/main/res/layout/custom_alert_dialog.xml
@@ -1,0 +1,45 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="16dp"
+    android:background="@drawable/rounded_dialog_background">
+
+    <TextView
+        android:id="@+id/customTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="20sp"
+        android:layout_marginBottom="8dp"
+        android:fontFamily="sans-serif-medium" />
+
+    <TextView
+        android:id="@+id/customMessage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="16sp"
+        android:fontFamily="sans-serif" />
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="end"
+        android:layout_marginTop="16dp">
+
+        <Button
+            android:id="@+id/cancelButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="?attr/colorOnSurface"
+            style="@style/Widget.MaterialComponents.Button.TextButton" />
+
+        <Button
+            android:id="@+id/confirmButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="?attr/colorOnSurface"
+            android:layout_marginStart="8dp"
+            style="@style/Widget.MaterialComponents.Button.TextButton" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_signup.xml
+++ b/app/src/main/res/layout/fragment_signup.xml
@@ -14,115 +14,118 @@
             android:id="@+id/profilePictureImageView"
             android:layout_width="100dp"
             android:layout_height="100dp"
-            android:src="@drawable/default_profile_pic"
-        android:layout_gravity="center"
-        android:scaleType="centerCrop"
-        android:layout_marginBottom="8dp"
-        android:contentDescription="Profile Picture" />
+            android:layout_gravity="center"
+            android:layout_marginBottom="8dp"
+            android:contentDescription="Profile Picture"
+            android:scaleType="centerCrop"
+            android:src="@drawable/default_profile_pic" />
 
         <!-- Button to choose a profile picture -->
         <Button
             android:id="@+id/chooseProfilePicButton"
+            style="@style/CustomButtonStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Choose Picture"
             android:layout_gravity="center"
-            android:backgroundTint="@color/highlight"
-            android:layout_marginBottom="16dp" />
+            android:layout_marginBottom="16dp"
+            android:text="Choose Picture" />
 
         <!-- Name -->
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="@color/highlight"
+            android:layout_marginBottom="4dp"
             android:text="Name"
-            android:layout_marginBottom="4dp" />
+            android:textColor="@color/highlight" />
 
         <EditText
             android:id="@+id/nameEditText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
             android:hint="Enter your name"
-            android:inputType="textPersonName"
-            android:layout_marginBottom="16dp" />
+            android:inputType="textPersonName" />
 
         <!-- Age -->
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="@color/highlight"
+            android:layout_marginBottom="4dp"
             android:text="Age"
-            android:layout_marginBottom="4dp" />
+            android:textColor="@color/highlight" />
 
         <EditText
             android:id="@+id/ageEditText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
             android:hint="Enter your age"
-            android:inputType="number"
-            android:layout_marginBottom="16dp" />
+            android:inputType="number" />
 
         <!-- Email -->
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="@color/highlight"
+            android:layout_marginBottom="4dp"
             android:text="Email"
-            android:layout_marginBottom="4dp" />
+            android:textColor="@color/highlight" />
 
         <EditText
             android:id="@+id/emailEditText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
             android:hint="Enter your email"
-            android:inputType="textEmailAddress"
-            android:layout_marginBottom="16dp" />
+            android:inputType="textEmailAddress" />
 
         <!-- Password -->
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="@color/highlight"
+            android:layout_marginBottom="4dp"
             android:text="Password"
-            android:layout_marginBottom="4dp" />
+            android:textColor="@color/highlight" />
 
         <EditText
             android:id="@+id/passwordEditText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
             android:hint="Enter your password"
-            android:inputType="textPassword"
-            android:layout_marginBottom="16dp" />
+            android:inputType="textPassword" />
 
         <!-- Competition Level (RadioGroup) -->
         <TextView
             android:layout_width="wrap_content"
-            android:textColor="@color/highlight"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="4dp"
             android:text="Competition Level"
-            android:layout_marginBottom="4dp" />
+            android:textColor="@color/highlight" />
 
         <RadioGroup
             android:id="@+id/competitionLevelGroup"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:layout_marginBottom="16dp">
+            android:layout_marginBottom="16dp"
+            android:orientation="horizontal">
 
             <RadioButton
                 android:id="@+id/radioBeginner"
+                style="@style/CustomRadioButtonStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Beginner" />
 
             <RadioButton
                 android:id="@+id/radioCasual"
+                style="@style/CustomRadioButtonStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Casual" />
 
             <RadioButton
                 android:id="@+id/radioCompetitive"
+                style="@style/CustomRadioButtonStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Competitive" />
@@ -132,34 +135,34 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="@color/highlight"
+            android:layout_marginBottom="4dp"
             android:text="Location"
-            android:layout_marginBottom="4dp" />
+            android:textColor="@color/highlight" />
 
         <EditText
             android:id="@+id/locationEditText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
             android:hint="Enter your location"
-            android:inputType="text"
-            android:layout_marginBottom="16dp" />
+            android:inputType="text" />
 
         <!-- Sign-Up Button -->
         <Button
             android:id="@+id/signUpButton"
+            style="@style/CustomButtonStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:backgroundTint="@color/highlight"
             android:text="Sign Up" />
 
         <!-- Go to signup -->
         <Button
             android:id="@+id/goToLoginButton"
+            style="@style/CustomButtonStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:backgroundTint="@color/highlight"
-            android:text="Already have an account? Log In"
-            android:layout_marginTop="16dp" />
+            android:layout_marginTop="16dp"
+            android:text="Already have an account? Log In" />
 
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -2,7 +2,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
-        android:id="@+id/playersFragment"
+        android:id="@+id/mainFragment"
         android:icon="@drawable/players_icon"
         android:title="Players"
         app:showAsAction="ifRoom" />

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -27,6 +27,9 @@
         <action
             android:id="@+id/action_signUpFragment_to_loginFragment"
             app:destination="@id/loginFragment" />
+        <action
+            android:id="@+id/action_signUpFragment_to_mainFragment"
+            app:destination="@id/mainFragment"/>
     </fragment>
 
     <!-- Main Fragment (Hosts Players and Games Tabs) -->
@@ -40,7 +43,7 @@
     <!-- Other Fragments for Bottom Navigation -->
     <fragment
         android:id="@+id/bookingFragment"
-        android:name="com.example.hoophubskeleton.fragment.BottomMenu.BookingsFragment"
+        android:name="com.example.hoophubskeleton.fragment.BottomMenu.BookingFragment"
         android:label="BookingsFragment"
         tools:layout="@layout/fragment_bookings"/>
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -41,4 +41,6 @@
         <item name="android:textColor">@color/text_icon_dark</item>
     </style>
 
+
+
 </resources>


### PR DESCRIPTION
Sign-up Fragment
- Now Navigates to "MainFragment" upon succesful signup.
- Needs better user validation
- Right now it is just blank fields

Login Fragment
- Basic User validation added
	- i.e. blank fields

EditDeleteProfile
- Navigation indicator is synced with parent (profileFragment tab is indicated when navigating away from editProfile)
- Profile is deleted when Delete is pressed
	- Dialog Appears preventing user error
	
AuthViewModel
- Added function to delete user credentials via repo

AuthRepo
- Added function to delete user credentials from FirebaseAuth

ProfileViewModel
- Added function to delete user profile from repo

ProfileRepository
- added function to delete user profile from Firestore


UI

Signup:
- Buttons style changed to "CustomButtonStyle"
- RadioButtons style changed to "CustomRadioButtonStyle"

Drawable:
- Made an orange rounded border background

Layout:
- Made a custon layout for alert dialogs

Navigation:

- Users can now go back to the main player bar (added it to the nav menu)
- edit/delete profile indicator lights up after moving away from profile fragment
